### PR TITLE
Expose Docker API to host network

### DIFF
--- a/scripts/configure_rancher_node.sh
+++ b/scripts/configure_rancher_node.sh
@@ -7,6 +7,7 @@ cache_ip=172.22.101.100
 if [ ! "$(ps -ef | grep dockerd | grep -v grep | grep "$cache_ip")" ]; then
   ros config set rancher.docker.registry_mirror "http://$cache_ip:5000"
   ros config set rancher.system_docker.registry_mirror "http://$cache_ip:5000"
+  ros config set rancher.docker.host "['unix:///var/run/docker.sock', 'tcp://0.0.0.0:2375']"
   system-docker restart docker
   sleep 5
 fi

--- a/scripts/configure_rancher_server.sh
+++ b/scripts/configure_rancher_server.sh
@@ -9,6 +9,7 @@ rancher_server_version=${4:-stable}
 if [ ! "$(ps -ef | grep dockerd | grep -v grep | grep "$cache_ip")" ]; then
   ros config set rancher.docker.registry_mirror "http://$cache_ip:5000"
   ros config set rancher.system_docker.registry_mirror "http://$cache_ip:5000"
+  ros config set rancher.docker.host "['unix:///var/run/docker.sock', 'tcp://0.0.0.0:2375']"
   system-docker restart docker
   sleep 5
 fi


### PR DESCRIPTION
Useful for interacting with the various daemons from the host machine. Here's some simple aliasing to go with it:
```
for x in $(seq 1 9); do
  for t in s n server node; do
    if [ "$t" == "s" ] || [ "$t" == "server" ]; then
      i=10$x
    else
      i=11$x
    fi
    alias "d$t$x"="export DOCKER_HOST=\"tcp://172.22.101.$i\"; \$@"
  done
done
```
Stick this in `~/.bash_profile` or similar and reap the benefits: `ds1 docker ps; dn1 docker ps; dnode2 docker ps; docker ps`