### PR TITLE
Use box version for server too

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,6 +52,7 @@ Vagrant.configure(2) do |config|
     hostname = "server-%02d" % i
     config.vm.define hostname do |server|
       server.vm.box= "chrisurwin/RancherOS"
+      server.vm.box_version = x.fetch('ROS_version')
       server.vm.guest = :linux
       server.vm.provider :virtualbox do |v|
         v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]


### PR DESCRIPTION
The `ROS_version` entry from config.yaml was only used for box version in the node section. This adds it to the server specification as well.

FWIW - `vagrant up` for a server node with the [1.0.4](https://vagrantcloud.com/chrisurwin/boxes/RancherOS/versions/1.0.4/providers/virtualbox.box) version hangs for me with vagant version 2.0.1 and virtualbox 5.0.14 at the "Waiting for machine to boot." step.