### PR TITLE
To enable 2.0, configure Server & master to pull rancher/rancher , not rancher/server.

### DIFF
--- a/scripts/configure_rancher_server.sh
+++ b/scripts/configure_rancher_server.sh
@@ -65,9 +65,9 @@ fi
 rancher_command=""
 if [ "$network_type" == "airgap" ]; then
   EXTRA_OPTS="-e CATTLE_BOOTSTRAP_REQUIRED_IMAGE=$cache_ip:5000/rancher/agent:v1.2.5"
-  rancher_command="$registry_prefix/rancher/server:$rancher_server_version" 
+  rancher_command="$registry_prefix/rancher/rancher:$rancher_server_version"
 else
-  rancher_command="rancher/server:$rancher_server_version" 
+  rancher_command="rancher/rancher:$rancher_server_version"
 fi
 
 echo Installing Rancher Server

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -230,10 +230,10 @@ curl -Ss  "http://localhost:7070/images/$rancher_server_version" | jq -r '.image
   done
   exists=$(curl -Ss http://$cache_ip:5000/v2/server/tags/list | jq -r '.tags' | grep $rancher_server_version)
   if [ "${#exists}" -gt "2" ]; then
-    echo "Image rancher/server:$rancher_server_version already in local cache"
+    echo "Image rancher/rancher:$rancher_server_version already in local cache"
   else
-    docker pull rancher/server:$rancher_server_version
-    docker tag rancher/server:$rancher_server_version $cache_ip:5000/rancher/server:$rancher_server_version
+    docker pull rancher/rancher:$rancher_server_version
+    docker tag rancher/rancher:$rancher_server_version $cache_ip:5000/rancher/rancher:$rancher_server_version
     docker push $cache_ip:5000/server:$rancher_server_version
   fi 
   exists=$(curl -Ss http://$cache_ip:5000/v2/rancher/agent/tags/list | jq -r '.tags' | grep v1.2.5)


### PR DESCRIPTION
Fixes #45.

I added a series of fixes to get this working with Rancher 2.0.  It works at least to the point that both worker nodes are working:

![image](https://user-images.githubusercontent.com/142752/46969137-f24bd680-d069-11e8-8f62-e94046defc99.png)

I confirmed that I can deploy workloads to it:

![image](https://user-images.githubusercontent.com/142752/46969099-d9432580-d069-11e8-9c90-6af331138a0d.png)