### PR TITLE
Further fixes for 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,19 @@ clone the directory and then run **vagrant up**
 
 This has been tested with vagrant 1.9.1 and VirtualBox 5.0.32. If you experience issues with the networking it is likely related to running an older version.
 
+To use Rancher 2.x, clone the repo and then switch to the 2.0 branch
+
+```
+git clone https://github.com/rancher/vagrant.git
+git checkout 2.0
+vagrant up
+```
+
 ## Config
 
 The config.yml contains any variables that you should need to change, below is a description of the variables and their values:
 
-**orchestrator** - Possible values are `cattle`, `kubernetes`, `mesos` and `swarm` 
+**orchestrator** - Works with 1.6 only. Possible values are `cattle`, `kubernetes`, `mesos` and `swarm` 
 
 This sets the orchestrator that will be used for the environment, as part of the process the Default environment is deleted and we create a new one with the name of the orchestrator. 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -62,7 +62,7 @@ Vagrant.configure(2) do |config|
       end
       server.vm.network x.fetch('net').fetch('network_type'), ip: IPAddr.new(server_ip.to_i + i - 1, Socket::AF_INET).to_s, nic_type: $private_nic_type
       server.vm.hostname = hostname
-      server.vm.provision "shell", path: "scripts/configure_rancher_server.sh", args: [x.fetch('ip').fetch('master'), x.fetch('default_password'), i, x.fetch('version'), x.fetch('network_mode'), x.fetch('sslenabled'), x.fetch('ssldns'), x.fetch('ip').fetch('master'), x.fetch('rancher_env_vars')]
+      server.vm.provision "shell", path: "scripts/configure_rancher_server.sh", args: [x.fetch('ip').fetch('master'), x.fetch('default_password'), i, x.fetch('version'), x.fetch('network_mode'), x.fetch('sslenabled'), x.fetch('ssldns'), x.fetch('ip').fetch('master'), x.fetch('rancher_env_vars'), x.fetch('kubernetes_version')]
       if File.file?(x.fetch('keys').fetch('private_key'))
         config.vm.provision "file", source: x.fetch('keys').fetch('private_key'), destination: "/home/rancher/.ssh/id_rsa"
       end

--- a/config.yaml
+++ b/config.yaml
@@ -4,13 +4,12 @@ network_mode: normal
 # 'true'|'false'
 sslenabled: 'false'
 ssldns: 'server.rancher.vagrant'
-# https://hub.docker.com/r/rancher/server/tags/
-version: master
+# https://hub.docker.com/r/rancher/rancher/tags/
+version: stable
 kubernetes_version: v1.11.2-rancher1-1
 #Pass through environment variables for Rancher Server to start with
 rancher_env_vars: ""
-agent_version: "v1.2.5"
-ROS_version: 1.0.3
+ROS_version: 1.4.0
 master:
   cpus: 1
   memory: 1024

--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ sslenabled: 'false'
 ssldns: 'server.rancher.vagrant'
 # https://hub.docker.com/r/rancher/server/tags/
 version: master
+kubernetes_version: v1.11.2-rancher1-1
 #Pass through environment variables for Rancher Server to start with
 rancher_env_vars: ""
 agent_version: "v1.2.5"

--- a/scripts/configure_rancher_node.sh
+++ b/scripts/configure_rancher_node.sh
@@ -20,12 +20,10 @@ if [ "$network_type" == "airgap" ] ; then
   curlprefix="$cache_ip:5000"
 fi
 
-#if [ "$orchestrator" == "kubernetes" ] && [ ! "$(ros engine list | grep current | grep docker-1.12.6)" ]; then
-  ros engine switch docker-1.12.6
-  ros config set rancher.docker.storage_driver overlay
-  system-docker restart docker
-  sleep 5
-#fi
+ros engine switch docker-1.12.6
+ros config set rancher.docker.storage_driver overlay
+system-docker restart docker
+sleep 5
 
 ros config set rancher.docker.insecure_registry "['$cache_ip:5000']"
 if [ ! "$network_type" == "airgap" ] ; then

--- a/scripts/configure_rancher_server.sh
+++ b/scripts/configure_rancher_server.sh
@@ -4,6 +4,7 @@ rancher_server_ip="172.22.101.101"
 default_password=${2:-password}
 node=${3:-3}
 rancher_server_version=${4:-stable}
+kubernetes_version=${10:-v1.11.2-rancher1-1}
 network_type=${5:-false}
 sslenabled=${6:-false}
 ssldns=${7:-server.rancher.vagrant}
@@ -119,7 +120,7 @@ CLUSTERRESPONSE=$(docker run --net host \
     --rm \
     $curl_prefix/curl \
      -s 'https://127.0.0.1/v3/cluster' -H 'content-type: application/json' -H "Authorization: Bearer $APITOKEN" \
-     --data-binary '{"type":"cluster","rancherKubernetesEngineConfig":{"ignoreDockerVersion":false,"sshAgentAuth":false,"type":"rancherKubernetesEngineConfig","kubernetesVersion":"v1.8.10-rancher1-1","authentication":{"type":"authnConfig","strategy":"x509"},"network":{"type":"networkConfig","plugin":"flannel","flannelNetworkProvider":{"iface":"eth1"},"calicoNetworkProvider":null},"ingress":{"type":"ingressConfig","provider":"nginx"},"services":{"type":"rkeConfigServices","kubeApi":{"podSecurityPolicy":false,"type":"kubeAPIService"},"etcd":{"type":"etcdService","extraArgs":{"heartbeat-interval":500,"election-timeout":5000}}}},"name":"myfirstcluster"}' --insecure)
+     --data-binary "{\"type\":\"cluster\",\"rancherKubernetesEngineConfig\":{\"ignoreDockerVersion\":false,\"sshAgentAuth\":false,\"type\":\"rancherKubernetesEngineConfig\",\"kubernetesVersion\":\"$kubernetes_version\",\"authentication\":{\"type\":\"authnConfig\",\"strategy\":\"x509\"},\"network\":{\"type\":\"networkConfig\",\"plugin\":\"flannel\",\"flannelNetworkProvider\":{\"iface\":\"eth1\"},\"calicoNetworkProvider\":null},\"ingress\":{\"type\":\"ingressConfig\",\"provider\":\"nginx\"},\"services\":{\"type\":\"rkeConfigServices\",\"kubeApi\":{\"podSecurityPolicy\":false,\"type\":\"kubeAPIService\"},\"etcd\":{\"type\":\"etcdService\",\"extraArgs\":{\"heartbeat-interval\":500,\"election-timeout\":5000}}}},\"name\":\"myfirstcluster\"}" --insecure)
 
 # Extract clusterid to use for generating the docker run command
 CLUSTERID=`echo $CLUSTERRESPONSE | jq -r .id`

--- a/scripts/configure_rancher_server.sh
+++ b/scripts/configure_rancher_server.sh
@@ -65,9 +65,9 @@ fi
 rancher_command=""
 if [ "$network_type" == "airgap" ]; then
   EXTRA_OPTS="-e CATTLE_BOOTSTRAP_REQUIRED_IMAGE=$cache_ip:5000/rancher/agent:v1.2.5"
-  rancher_command="$registry_prefix/rancher/server:$rancher_server_version" 
+  rancher_command="$registry_prefix/rancher/rancher:$rancher_server_version"
 else
-  rancher_command="rancher/server:$rancher_server_version" 
+  rancher_command="rancher/rancher:$rancher_server_version"
 fi
 
 echo Installing Rancher Server

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -230,10 +230,10 @@ curl -Ss  "http://localhost:7070/images/$rancher_server_version" | jq -r '.image
   done
   exists=$(curl -Ss http://$cache_ip:5000/v2/server/tags/list | jq -r '.tags' | grep $rancher_server_version)
   if [ "${#exists}" -gt "2" ]; then
-    echo "Image rancher/server:$rancher_server_version already in local cache"
+    echo "Image rancher/rancher:$rancher_server_version already in local cache"
   else
-    docker pull rancher/server:$rancher_server_version
-    docker tag rancher/server:$rancher_server_version $cache_ip:5000/rancher/server:$rancher_server_version
+    docker pull rancher/rancher:$rancher_server_version
+    docker tag rancher/rancher:$rancher_server_version $cache_ip:5000/rancher/rancher:$rancher_server_version
     docker push $cache_ip:5000/server:$rancher_server_version
   fi 
   exists=$(curl -Ss http://$cache_ip:5000/v2/rancher/agent/tags/list | jq -r '.tags' | grep v1.2.5)


### PR DESCRIPTION
I'm contributing a few additional fixes for 2.0. They are summarized as:

- Update the version of RancherOS
- Use the `:stable` branch of the rancher/rancher image
- Enable the use of $kubernetes_version so we can play with newer version of k8s. 
- Remove some kruft from the code
- Update the README.

This project works. I've been using it on and off for 4 weeks, and it also works for my colleague.
