### PR TITLE
Add a script to purge vms during development.

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -4,21 +4,21 @@ hosts:
   role:
   - controlplane
   - etcd
-  advertised_hostname: training-01
+  advertised_hostname: node-01
   user: vagrant
   docker_socket: /var/run/docker.sock
 - ip: 172.22.101.112
   advertise_address: 172.22.101.112
   role:
   - worker
-  advertised_hostname: training-02
+  advertised_hostname: node-02
   user: vagrant
   docker_socket: /var/run/docker.sock
 - ip: 172.22.101.113
   advertise_address: 172.22.101.113
   role:
   - worker
-  advertised_hostname: training-03
+  advertised_hostname: node-03
   user: vagrant
   docker_socket: /var/run/docker.sock
 services:

--- a/cluster.yml
+++ b/cluster.yml
@@ -1,0 +1,56 @@
+hosts:
+- ip: 172.22.101.111
+  advertise_address: 172.22.101.111
+  role:
+  - controlplane
+  - etcd
+  advertised_hostname: training-01
+  user: vagrant
+  docker_socket: /var/run/docker.sock
+- ip: 172.22.101.112
+  advertise_address: 172.22.101.112
+  role:
+  - worker
+  advertised_hostname: training-02
+  user: vagrant
+  docker_socket: /var/run/docker.sock
+- ip: 172.22.101.113
+  advertise_address: 172.22.101.113
+  role:
+  - worker
+  advertised_hostname: training-03
+  user: vagrant
+  docker_socket: /var/run/docker.sock
+services:
+  etcd:
+    image: quay.io/coreos/etcd:latest
+    extra_args: {}
+  kube-api:
+    image: quay.io/coreos/hyperkube:v1.7.5_coreos.0
+    extra_args: {}
+    service_cluster_ip_range: 10.233.0.0/18
+  kube-controller:
+    image: quay.io/coreos/hyperkube:v1.7.5_coreos.0
+    extra_args: {}
+    cluster_cidr: 10.233.64.0/18
+    service_cluster_ip_range: 10.233.0.0/18
+  scheduler:
+    image: quay.io/coreos/hyperkube:v1.7.5_coreos.0
+    extra_args: {}
+  kubelet:
+    image: quay.io/coreos/hyperkube:v1.7.5_coreos.0
+    extra_args: {}
+    cluster_domain: cluster.local
+    infra_container_image: gcr.io/google_containers/pause-amd64:3.0
+    cluster_dns_server: 10.233.0.3
+  kubeproxy:
+    image: quay.io/coreos/hyperkube:v1.7.5_coreos.0
+    extra_args: {}
+network:
+  plugin: flannel
+  options: {}
+auth:
+  strategy: x509
+  options: {}
+addons: ""
+ssh_key_path: "/home/vagrant/id_rsa"

--- a/config.yaml
+++ b/config.yaml
@@ -1,13 +1,8 @@
-# cattle|kubernetes|swarm|mesos
-orchestrator: cattle
-# 'true'|'false' isolated network requiring proxy. must be in ''
+orchestrator: kubernetes
 network_mode: normal
-# 'true'|'false'
 sslenabled: 'false'
 ssldns: 'server.rancher.vagrant'
-# https://hub.docker.com/r/rancher/server/tags/
 version: latest
-#Pass through environment variables for Rancher Server to start with
 rancher_env_vars: ""
 agent_version: "v1.2.5"
 ROS_version: 1.0.3
@@ -19,7 +14,7 @@ server:
   cpus: 1
   memory: 2048
 node:
-  count: 3
+  count: 2
   cpus: 1
   memory: 2048
 ip:

--- a/config.yaml
+++ b/config.yaml
@@ -6,9 +6,9 @@ network_mode: normal
 sslenabled: 'false'
 ssldns: 'server.rancher.vagrant'
 # https://hub.docker.com/r/rancher/server/tags/
-version: latest
+version: preview
 #Pass through environment variables for Rancher Server to start with
-rancher_env_vars: ""
+rancher_env_vars: "-e CATTLE_API_HOST=http://172.22.101.100 -v /var/run/docker.sock:/var/run/docker.sock"
 agent_version: "v1.2.5"
 ROS_version: 1.0.3
 master:

--- a/scripts/configure_rancher_node.sh
+++ b/scripts/configure_rancher_node.sh
@@ -6,109 +6,27 @@ sslenabled=${4:-false}
 ssldns=${5:-server.rancher.vagrant}
 cache_ip=${6:-172.22.101.100}
 
-curlprefix="appropriate"
-if [ "$sslenabled" == 'true' ]; then
-  protocol="https"
-  rancher_server_ip=$ssldns
-else
-  protocol="http"
-fi
 
-if [ "$network_type" == "airgap" ] ; then
-  curlprefix="$cache_ip:5000"
-fi
+      sed 's/127\.0\.0\.1.*node.*/172\.22\.101\.11#{i} node-0#{i}/' -i /etc/hosts
+      apt-get update && apt-get install -y apt-transport-https
+      curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+      echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+      apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+      mkdir -p /etc/apt/sources.list.d
+      echo "deb https://apt.dockerproject.org/repo ubuntu-xenial main" | tee /etc/apt/sources.list.d/docker.list
+      apt-get update
+      apt-get install -y kubelet kubeadm kubectl  
+      apt-get -y install docker-engine=1.12.6-0~ubuntu-xenial
+      swapoff -a  
 
-if [ "$orchestrator" == "kubernetes" ] && [ ! "$(ros engine list | grep current | grep docker-1.12.6)" ]; then
-  ros engine switch docker-1.12.6
-  system-docker restart docker
-  sleep 5
-fi
+      if [ "$HOSTNAME" == "node-01" ]; then
+          ssh-keygen -f id_rsa -t rsa -N ''
+          sed -i -e 's/root@node-01/vagrant/g' id_rsa.pub
+          docker run -d -p 7777:8043 -v /home/vagrant:/srv/http --name goStatic pierrezemb/gostatic
+          cat /home/vagrant/id_rsa.pub >> /home/vagrant/.ssh/authorized_keys
 
-ros config set rancher.docker.insecure_registry "['$cache_ip:5000']"
-if [ ! "$network_type" == "airgap" ] ; then
-  ros config set rancher.docker.registry_mirror "http://$cache_ip:4000"
-  ros config set rancher.system_docker.registry_mirror "http://$cache_ip:4000"
-  ros config set rancher.docker.host "['unix:///var/run/docker.sock', 'tcp://0.0.0.0:2375']"
-  if [ "$network_type" == "isolated" ]; then
-    ros config set rancher.docker.environment "['http_proxy=http://$cache_ip:3128','https_proxy=http://$cache_ip:3128','HTTP_PROXY=http://$cache_ip:3128','HTTPS_PROXY=http://$cache_ip:3128','no_proxy=server.rancher.vagrant,localhost,127.0.0.1','NO_PROXY=server.rancher.vagrant,localhost,127.0.0.1']"
-    ros config set rancher.system_docker.environment "['http_proxy=http://$cache_ip:3128','https_proxy=http://$cache_ip:3128','HTTP_PROXY=http://$cache_ip:3128','HTTPS_PROXY=http://$cache_ip:3128','no_proxy=server.rancher.vagrant,localhost,127.0.0.1','NO_PROXY=server.rancher.vagrant,localhost,127.0.0.1']"
-  fi
-fi
-
-system-docker restart docker
-sleep 5
-
-if [ "$sslenabled" == 'true' ]; then
-mkdir -p /var/lib/rancher/etc/ssl
-echo "-----BEGIN CERTIFICATE-----
-MIIDFTCCAf2gAwIBAgIJAN2yyLTWbidBMA0GCSqGSIb3DQEBBQUAMCExHzAdBgNV
-BAMMFnNlcnZlci5yYW5jaGVyLnZhZ3JhbnQwHhcNMTcwNzI5MTQxMjQ1WhcNMjcw
-NzI3MTQxMjQ1WjAhMR8wHQYDVQQDDBZzZXJ2ZXIucmFuY2hlci52YWdyYW50MIIB
-IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwLq7oWQwnSAR696FL7w2W7t/
-MVCioPnnJV8tFfTvIZ/zQsH4ul9rjdv0NGLcPEXXtdDxsadn+hMWUYAqPNn2YDav
-pa0HhEFL/WGnUAP/XE2Vrop7QYh/heu8BIOOQ2rAOaxlLUscDYSmA3BeIEIoDLSc
-+A9+xVMikc6SkSQ4qpZOF7GvLfbwEYs3ii7PFUTzxDbmWsOuEEyRyJ36+6fmTTIu
-w6rrnsCqUF7AfIEcgxEVOTxtMoY/v8427AP+0B4pAGrY7siwqoiXtWERraVuyAwn
-0IkKK4LH/lH30KwzPZTV825aE2Ob05MAg3Sbgi83BfMZQpbloJKj/MosmcXfGwID
-AQABo1AwTjAdBgNVHQ4EFgQUXlHYBOn21xjD64UiFrQa+hoFFyIwHwYDVR0jBBgw
-FoAUXlHYBOn21xjD64UiFrQa+hoFFyIwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
-AQUFAAOCAQEAQo+VJv2VkXAe03RL5PBSopE50XNF0xUvMH45gt2lnh4bz2HXTaLy
-XcbMzFWeClKWvkqfb9vhlClhmusJYYzkWsSJ5il7YNYVI4m+z33XtTeR0Pzuy2XQ
-BrRf+kz6KP5DJt1HusTN+gJFJ0EI850USscCjR2TiPWe7zgKt8WJ/W5c3rVwLFy5
-Z/nsoi16UmSJXKkJzXA+tM6K5DCx1p4LmuZXSzB5EwkL9okqA903Vj6kv9JwaHJl
-4IgQPgzN0f5iPZNsMboEFfhcYVRRYoznnJzL7VCg1ig5j9JyfsjSpozVFE2CY/52
-tRubyXjH+dQQftBUuzwULwwKGL0le7o/vA==
------END CERTIFICATE-----" > /var/lib/rancher/etc/ssl/ca.crt
-fi
-
-if [ "$network_type" == "isolated" ] || [ "$network_type" == "airgap" ] ; then
-  ros config set rancher.network.dns.nameservers ["'$cache_ip'"]
-  system-docker restart network
-  route add default gw $cache_ip
-fi
-
-if [ "$sslenabled" == 'true' ]; then
-  ros config set rancher.network.dns.nameservers ["'$cache_ip'"]
-  system-docker restart network
-  mkdir -p /var/lib/rancher/etc/ssl
-  cp /home/rancher/ca.crt /var/lib/rancher/etc/ssl/ca.crt
-fi
-
-while true; do
-  ENV_ID=$(docker run \
-    -v /tmp:/tmp \
-    --rm \
-    $curlprefix/curl \
-      -sLk \
-      "$protocol://$rancher_server_ip/v2-beta/project?name=$orchestrator" | jq '.data[0].id' | tr -d '"')
-
-  if [[ "$ENV_ID" == 1a* ]]; then
-    break
-  else
-    sleep 5
-  fi
-done
-
-
-echo Adding host to Rancher Server
-
-docker run \
-  -v /tmp:/tmp \
-  --rm \
-  $curlprefix/curl \
-    -sLk \
-    -X POST \
-    -H 'Content-Type: application/json' \
-    -H 'accept: application/json' \
-    -d "{\"type\":\"registrationToken\"}" \
-      "$protocol://$rancher_server_ip/v2-beta/projects/$ENV_ID/registrationtoken"
-
-docker run \
-  -v /tmp:/tmp \
-  --rm \
-  $curlprefix/curl \
-    -sLk \
-    "$protocol://$rancher_server_ip/v2-beta/projects/$ENV_ID/registrationtokens/?state=active" |
-      jq -r .data[].command |
-      head -n1 |
-      sh
+      fi
+      if [ "$HOSTNAME" != "node-01" ]; then
+          curl http://172.22.101.111:7777/id_rsa.pub >> /home/vagrant/.ssh/authorized_keys
+      fi
+      service ssh restart  

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -314,3 +314,13 @@ fi
 echo "if [ -f /var/run/vboxadd-service.pid ]; then
   mount -t vboxsf -o uid=900,gid=900,rw vagrant /vagrant
 fi" > /etc/rc.local
+
+
+#RKE configuration
+
+curl http://172.22.101.111:7777/id_rsa > id_rsa
+chmod 0400 id_rsa
+curl -L https://github.com/rancher/rke/releases/download/v0.0.3-dev/rke_linux-amd64 > rke
+chmod +x rke
+./rke cluster up
+#pull down RKE

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -323,4 +323,5 @@ chmod 0400 id_rsa
 curl -L https://github.com/rancher/rke/releases/download/v0.0.3-dev/rke_linux-amd64 > rke
 chmod +x rke
 ./rke cluster up
+chown vagrant id_rsa
 #pull down RKE

--- a/scripts/purge_vms.sh
+++ b/scripts/purge_vms.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for i in $(VBoxManage list vms | awk '{print $2}'); do
+	echo "$i"
+	VBoxManage controlvm $i poweroff
+        VBoxManage unregistervm $i --delete
+done


### PR DESCRIPTION
Problem Statement:
In most cases the fact that the vagrant script does not clean up virtual machines is not a problem.  But for people working to iterate on deployment and testing where it's necessary to spin up a fresh environment to isolate variables, manually cleaning out VMs is a pain point.

Solution:
This pull request provides a simple script that will destroy all VMs in a given virtualbox environment.  It's a script I have been using for years, which I figure others can use in this project.